### PR TITLE
Add octoprint role to ansible threedee server

### DIFF
--- a/homelab/ansible/02-threedee.yml
+++ b/homelab/ansible/02-threedee.yml
@@ -1,0 +1,7 @@
+---
+- name: Setup 3D Printer Server
+  hosts: threedee
+  gather_facts: true
+  become: true
+  roles:
+    - octoprint

--- a/homelab/ansible/roles/octoprint/README.md
+++ b/homelab/ansible/roles/octoprint/README.md
@@ -1,0 +1,27 @@
+# Octoprint
+
+Sets up Octoprint server.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+None.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yml
+- hosts: servers
+  roles:
+    - octoprint
+```
+
+## License
+
+MIT

--- a/homelab/ansible/roles/octoprint/meta/main.yml
+++ b/homelab/ansible/roles/octoprint/meta/main.yml
@@ -1,0 +1,26 @@
+galaxy_info:
+  author: sonofborge
+  description: Sets up Octoprint server.
+  license: MIT
+  min_ansible_version: "2.1"
+
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy # 22.04
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/homelab/ansible/roles/octoprint/tasks/main.yml
+++ b/homelab/ansible/roles/octoprint/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Install Octoprint via Snap
+  community.general.snap:
+    name: octoprint-pfs
+    channel: latest/edge
+    state: present

--- a/homelab/ansible/roles/octoprint/vars/main.yml
+++ b/homelab/ansible/roles/octoprint/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for octoprint


### PR DESCRIPTION
## Describe your changes

Add Octoprint to threedee server via Ansible role.  Just doing these server-level installs fast via Snap... not at all sophisticated... just dirty and fast.